### PR TITLE
fix: `types` should always come first in `exports`

### DIFF
--- a/.changeset/pink-humans-call.md
+++ b/.changeset/pink-humans-call.md
@@ -1,0 +1,7 @@
+---
+"prettier-plugin-pkg": patch
+"prettier-plugin-sh": patch
+"prettier-plugin-sql": patch
+---
+
+fix: `types` should always come first in `exports`

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "node": "14",
+  "node": "16",
   "packages": [
     "packages/*"
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - 12
           - 14
           - 16
+          - 18
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 14.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - name: Install Dependencies

--- a/packages/pkg/package.json
+++ b/packages/pkg/package.json
@@ -13,9 +13,9 @@
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "exports": {
+    "types": "./lib/index.d.ts",
     "import": "./lib/index.js",
-    "require": "./lib/index.cjs",
-    "types": "./lib/index.d.ts"
+    "require": "./lib/index.cjs"
   },
   "types": "./lib/index.d.ts",
   "files": [

--- a/packages/sh/package.json
+++ b/packages/sh/package.json
@@ -13,9 +13,9 @@
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "exports": {
+    "types": "./lib/index.d.ts",
     "import": "./lib/index.js",
-    "require": "./lib/index.cjs",
-    "types": "./lib/index.d.ts"
+    "require": "./lib/index.cjs"
   },
   "types": "./lib/index.d.ts",
   "files": [

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -13,9 +13,9 @@
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "exports": {
+    "types": "./lib/index.d.ts",
     "import": "./lib/index.js",
-    "require": "./lib/index.cjs",
-    "types": "./lib/index.d.ts"
+    "require": "./lib/index.cjs"
   },
   "types": "./lib/index.d.ts",
   "files": [


### PR DESCRIPTION
ref: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-beta/#package-json-exports-imports-and-self-referencing